### PR TITLE
[chore] unify the syntax for the git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "Cores/DeltaCore"]
 	path = Cores/DeltaCore
-	url = git@github.com:lonkelle/DeltaCore.git
+	url = https://github.com/lonkelle/DeltaCore.git
 [submodule "Cores/SNESDeltaCore"]
 	path = Cores/SNESDeltaCore
-	url = git@github.com:lonkelle/SNESDeltaCore.git
+	url = https://github.com/lonkelle/SNESDeltaCore.git
 [submodule "External/Roxas"]
 	path = External/Roxas
-	url = git@github.com:lonkelle/Roxas.git
+	url = https://github.com/lonkelle/Roxas.git
 [submodule "Cores/GBADeltaCore"]
 	path = Cores/GBADeltaCore
-	url = git@github.com:lonkelle/GBADeltaCore.git
+	url = https://github.com/lonkelle/GBADeltaCore.git
 [submodule "Cores/GBCDeltaCore"]
 	path = Cores/GBCDeltaCore
-	url = git@github.com:lonkelle/GBCDeltaCore.git
+	url = https://github.com/lonkelle/GBCDeltaCore.git
 [submodule "External/Harmony"]
 	path = External/Harmony
 	url = https://github.com/lonkelle/Harmony.git
 [submodule "Cores/NESDeltaCore"]
 	path = Cores/NESDeltaCore
-	url = git@github.com:lonkelle/NESDeltaCore.git
+	url = https://github.com/lonkelle/NESDeltaCore.git
 [submodule "Cores/N64DeltaCore"]
 	path = Cores/N64DeltaCore
-	url = git@github.com:lonkelle/N64DeltaCore.git
+	url = https://github.com/lonkelle/N64DeltaCore.git
 [submodule "Cores/DSDeltaCore"]
 	path = Cores/DSDeltaCore
 	url = https://github.com/lonkelle/DSDeltaCore.git


### PR DESCRIPTION
For your consideration. I've always had to do this in order to clone the submodules on Delta, and I had to do it here too. Maybe something with my git configuration? Either way, I've never liked that the syntaxes are mixed.

This is of course more of a personal nit than anything else. Feel free to close/reject if this isn't wanted.